### PR TITLE
fix: update CLI install location to match CLI v8 location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## v1.1.0
+- Update CLI install path to v8 default path
+
 ## v1
 
 - Adds user agent to curl/wget  (https://github.com/heroku/heroku-buildpack-cli/pull/9)

--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ source /dev/stdin <<< "$(curl -s --retry 3 https://lang-common.s3.amazonaws.com/
 BUILD_DIR=$1
 CACHE_DIR=$2
 BUILDPACK_DIR="$(dirname $(dirname "$0"))"
-HEROKU_CLI_URL="https://cli-assets.heroku.com/heroku-linux-x64.tar.xz"
+HEROKU_CLI_URL="https://cli-assets.heroku.com/channels/stable/heroku-linux-x64.tar.xz"
 
 puts_step "Fetching and vendoring Heroku CLI into slug"
 rm -rf "$BUILD_DIR/.heroku/cli"


### PR DESCRIPTION
The existing location will only ever install v7 of CLI. Point to the default path for v8 releases.

The updated path was verified by downloading assets in browser.