### PR TITLE
fix: the jq expression to select the correct version from the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## v1.2.1
+- Fixes a bug in the `jq` query that was selecting the incorrect version, when the `.heroku-cli-version` file specified `alpha` or `beta`
+
 ## v1.2.0
 - Adds support for a `.heroku-cli-version` file for pinning to a specific version of the Heroku CLI.
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ If the version is invalid, or if this file is not present, this buildpack will u
     alpha           # uses the latest alpha release of the CLI
     beta            # uses the latest beta release of the CLI
     invalid-version # Falls-back to the stable release of the CLI
+    
+Running Test
+------------
+
+`make test` to run all tests.
+
+> Note: For MacOS users, these tests require the `timeout` command. The simplest way to get that is running `brew install coreutils`.

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ fetch_asset() {
 
 get_prerelease_url() {
   local release=$1
-  jq -r --arg release "$release" 'to_entries | map(select(.key | contains($release))) | max_by(.key | capture("(?<major>\\\\d+)\\\\.(?<minor>\\\\d+)\\\\.(?<patch>\\\\d+)-" + $release + "\\\\.(?<pre>\\\\d+)") | [.major, .minor, .patch, .pre] | map(tonumber)) | .value'
+  jq -r --arg release "$release" 'to_entries | map(select(.key | contains($release))) | max_by(.key | capture("(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-" + $release + "\\.(?<pre>\\d+)") | [.major, .minor, .patch, .pre] | map(tonumber)) | .value'
 }
 
 if [[ -s "$HEROKU_CLI_VERSION_FILE" ]]; then

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -186,9 +186,6 @@ test_beta_version() {
   run_compile_until_download
 
   # Should show beta-specific message
-  echo "--------------------------------"
-  cat "$TEST_OUTPUT"
-  echo "--------------------------------"
   if grep -q "Finding latest beta release" "$TEST_OUTPUT"; then
     pass "Detects beta version request"
   else

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -66,7 +66,7 @@ run_compile_until_download() {
 
   # Run compile but timeout after 1 second (just enough to see version resolution)
   # Capture output up to the download attempt
-  timeout 1s "$buildpack_dir/bin/compile" "$TEST_BUILD_DIR" "$TEST_CACHE_DIR" 2>&1 | tee "$TEST_OUTPUT" || true
+  timeout 2s "$buildpack_dir/bin/compile" "$TEST_BUILD_DIR" "$TEST_CACHE_DIR" 2>&1 | tee "$TEST_OUTPUT" || true
 }
 
 ###############################################################################
@@ -186,6 +186,9 @@ test_beta_version() {
   run_compile_until_download
 
   # Should show beta-specific message
+  echo "--------------------------------"
+  cat "$TEST_OUTPUT"
+  echo "--------------------------------"
   if grep -q "Finding latest beta release" "$TEST_OUTPUT"; then
     pass "Detects beta version request"
   else

--- a/test/fixtures/registry.json
+++ b/test/fixtures/registry.json
@@ -9,6 +9,8 @@
   "11.0.0-alpha.27": "https://cli-assets.heroku.com/versions/11.0.0-alpha.27/37c18bd/heroku-v11.0.0-alpha.27-37c18bd-linux-x64.tar.xz",
   "11.0.0-alpha.28": "https://cli-assets.heroku.com/versions/11.0.0-alpha.28/7458336/heroku-v11.0.0-alpha.28-7458336-linux-x64.tar.xz",
   "11.0.0-alpha.29": "https://cli-assets.heroku.com/versions/11.0.0-alpha.29/9537059/heroku-v11.0.0-alpha.29-9537059-linux-x64.tar.xz",
+  "11.0.0-alpha.30": "https://cli-assets.heroku.com/versions/11.0.0-alpha.30/73f4bbf/heroku-v11.0.0-alpha.30-73f4bbf-linux-x64.tar.xz",
+  "11.0.0-beta.0": "https://cli-assets.heroku.com/versions/11.0.0-beta.0/12e6901/heroku-v11.0.0-beta.0-12e6901-linux-x64.tar.xz",
   "10.17.0-beta.0": "https://cli-assets.heroku.com/versions/10.17.0-beta.0/3a3fb69/heroku-v10.17.0-beta.0-3a3fb69-linux-x64.tar.xz",
   "10.17.0": "https://cli-assets.heroku.com/versions/10.17.0/8f921d2/heroku-v10.17.0-8f921d2-linux-x64.tar.xz",
   "10.16.0-beta.0": "https://cli-assets.heroku.com/versions/10.16.0-beta.0/5491b54/heroku-v10.16.0-beta.0-5491b54-linux-x64.tar.xz",


### PR DESCRIPTION
This PR fixes a bug that was causing `jq` to select the incorrect CLI version, when provided `alpha` or `beta` in the version file.

## SOC 2 Compliance
[W-19367978](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002KLD17YAH/view)